### PR TITLE
feat: [EL-3414] Add bucket expiration notifications

### DIFF
--- a/api/v1/buckets.py
+++ b/api/v1/buckets.py
@@ -11,6 +11,16 @@ from pylon.core.tools import log
 from tools import MinioClient, api_tools, auth
 
 
+def _update_bucket_tags(mc, bucket, new_tags):
+    response = mc.get_bucket_tags(bucket)
+    existing_tags = {
+        tag['Key']: tag['Value']
+        for tag in response.get('TagSet', [])
+    } if response else {}
+    existing_tags.update(new_tags)
+    mc.set_bucket_tags(bucket=bucket, tags=existing_tags)
+
+
 def calculate_retention_days(project, expiration_value, expiration_measure):
     data_retention_limit = project.get_data_retention_limit()
     days = data_retention_limit or None
@@ -85,6 +95,35 @@ class ProjectAPI(api_tools.APIModeHandler):
         response = mc.create_bucket(bucket=bucket, bucket_type='local')
         if isinstance(response, dict) and response['Location'] and days:
             mc.configure_bucket_lifecycle(bucket=bucket, days=days)
+
+            today = datetime.today().date()
+            expiration_date = today + relativedelta(**{expiration_measure: int(expiration_value)})
+            _update_bucket_tags(mc, bucket, {
+                'expiration_date': expiration_date.isoformat(),
+                'notified_warnings': '',
+            })
+
+            if expiration_measure == 'days':
+                try:
+                    current_user = auth.current_user()
+                    user_id = current_user.get('id')
+                    if user_id:
+                        self.module.context.event_manager.fire_event(
+                            'notifications_stream', {
+                                'project_id': project_id,
+                                'user_id': user_id,
+                                'meta': {
+                                    'bucket_name': bucket,
+                                    'expiration_date': expiration_date.isoformat(),
+                                    'days_remaining': days,
+                                    'warning_threshold': 0,
+                                },
+                                'event_type': 'bucket_expiration_warning',
+                            }
+                        )
+                except Exception as e:
+                    log.warning('Failed to send immediate bucket expiration notification: %s', e)
+
             return {
                 "message": "Created",
                 "id": response['Location'].lstrip('/'),
@@ -118,6 +157,14 @@ class ProjectAPI(api_tools.APIModeHandler):
         if days:
             try:
                 mc.configure_bucket_lifecycle(bucket=bucket, days=days)
+
+                today = datetime.today().date()
+                expiration_date = today + relativedelta(**{expiration_measure: int(expiration_value)})
+                _update_bucket_tags(mc, bucket, {
+                    'expiration_date': expiration_date.isoformat(),
+                    'notified_warnings': '',
+                })
+
                 return {"message": f"Updated", "id": f"p--{project_id}.{bucket}"}, 200
             except Exception as e:
                 return {"message": str(e), "id": f"p--{project_id}.{bucket}"}, 400

--- a/api/v2/buckets.py
+++ b/api/v2/buckets.py
@@ -11,6 +11,16 @@ from pylon.core.tools import log
 from tools import MinioClient, api_tools, auth
 
 
+def _update_bucket_tags(mc, bucket, new_tags):
+    response = mc.get_bucket_tags(bucket)
+    existing_tags = {
+        tag['Key']: tag['Value']
+        for tag in response.get('TagSet', [])
+    } if response else {}
+    existing_tags.update(new_tags)
+    mc.set_bucket_tags(bucket=bucket, tags=existing_tags)
+
+
 def calculate_retention_days(project, expiration_value, expiration_measure):
     data_retention_limit = project.get_data_retention_limit()
     days = data_retention_limit or None
@@ -85,6 +95,35 @@ class ProjectAPI(api_tools.APIModeHandler):
         response = mc.create_bucket(bucket=bucket, bucket_type='local')
         if isinstance(response, dict) and response['Location'] and days:
             mc.configure_bucket_lifecycle(bucket=bucket, days=days)
+
+            today = datetime.today().date()
+            expiration_date = today + relativedelta(**{expiration_measure: int(expiration_value)})
+            _update_bucket_tags(mc, bucket, {
+                'expiration_date': expiration_date.isoformat(),
+                'notified_warnings': '',
+            })
+
+            if expiration_measure == 'days':
+                try:
+                    current_user = auth.current_user()
+                    user_id = current_user.get('id')
+                    if user_id:
+                        self.module.context.event_manager.fire_event(
+                            'notifications_stream', {
+                                'project_id': project_id,
+                                'user_id': user_id,
+                                'meta': {
+                                    'bucket_name': bucket,
+                                    'expiration_date': expiration_date.isoformat(),
+                                    'days_remaining': days,
+                                    'warning_threshold': 0,
+                                },
+                                'event_type': 'bucket_expiration_warning',
+                            }
+                        )
+                except Exception as e:
+                    log.warning('Failed to send immediate bucket expiration notification: %s', e)
+
             return {
                 "message": "Created",
                 "id": response['Location'].lstrip('/'),
@@ -118,6 +157,14 @@ class ProjectAPI(api_tools.APIModeHandler):
         if days:
             try:
                 mc.configure_bucket_lifecycle(bucket=bucket, days=days)
+
+                today = datetime.today().date()
+                expiration_date = today + relativedelta(**{expiration_measure: int(expiration_value)})
+                _update_bucket_tags(mc, bucket, {
+                    'expiration_date': expiration_date.isoformat(),
+                    'notified_warnings': '',
+                })
+
                 return {"message": f"Updated", "id": f"p--{project_id}.{bucket}"}, 200
             except Exception as e:
                 return {"message": str(e), "id": f"p--{project_id}.{bucket}"}, 400

--- a/module.py
+++ b/module.py
@@ -130,5 +130,3 @@ class Module(module.ModuleModel):
             log.warning('Configurations plugin rpc not available')
 
 
-
-

--- a/rpc/bucket_expiration.py
+++ b/rpc/bucket_expiration.py
@@ -1,0 +1,122 @@
+from datetime import date
+
+from pylon.core.tools import web, log
+
+from tools import MinioClient
+
+
+def _get_notification_thresholds(total_days):
+    """Get warning thresholds (days before expiration) based on total retention period."""
+    if total_days >= 365:
+        return [30, 7, 1]
+    elif total_days >= 30:
+        return [7, 1]
+    elif total_days >= 7:
+        return [5]
+    return []  # days retention - handled at creation time
+
+
+def _get_notified_set(tags):
+    """Get set of already-notified threshold days from bucket tags."""
+    notified_str = tags.get('notified_warnings', '')
+    if not notified_str:
+        return set()
+    return {int(x) for x in notified_str.split(',') if x.strip().isdigit()}
+
+
+class RPC:
+    @web.rpc('artifacts_check_bucket_expiration_notifications')
+    def check_bucket_expiration_notifications(self):
+        try:
+            project_list = self.context.rpc_manager.timeout(30).project_list(
+                filter_={'create_success': True}
+            )
+        except Exception as e:
+            log.warning('Failed to get project list for bucket expiration check: %s', e)
+            return
+
+        today = date.today()
+
+        for project in project_list:
+            project_id = project['id']
+            try:
+                mc = MinioClient(project)
+                buckets = mc.list_bucket()
+            except Exception as e:
+                log.warning('Failed to access MinIO for project %s: %s', project_id, e)
+                continue
+
+            for bucket in buckets:
+                try:
+                    lifecycle = mc.get_bucket_lifecycle(bucket)
+                    rules = lifecycle.get('Rules', [])
+                    if not rules:
+                        continue
+
+                    total_days = rules[0].get('Expiration', {}).get('Days')
+                    if not total_days:
+                        continue
+
+                    tag_response = mc.get_bucket_tags(bucket)
+                    tags = {
+                        tag['Key']: tag['Value']
+                        for tag in tag_response.get('TagSet', [])
+                    } if tag_response else {}
+
+                    expiration_date_str = tags.get('expiration_date')
+                    if not expiration_date_str:
+                        continue
+
+                    expiration_date = date.fromisoformat(expiration_date_str)
+                    days_remaining = (expiration_date - today).days
+
+                    if days_remaining < 0:
+                        continue
+
+                    thresholds = _get_notification_thresholds(total_days)
+                    notified = _get_notified_set(tags)
+
+                    new_notifications = [
+                        t for t in thresholds
+                        if days_remaining <= t and t not in notified
+                    ]
+
+                    if not new_notifications:
+                        continue
+
+                    try:
+                        user_ids = self.context.rpc_manager.timeout(5).admin_get_users_ids_in_project(
+                            project_id
+                        )
+                    except Exception as e:
+                        log.warning('Failed to get users for project %s: %s', project_id, e)
+                        continue
+
+                    for threshold in new_notifications:
+                        for user_id in user_ids:
+                            self.context.event_manager.fire_event(
+                                'notifications_stream', {
+                                    'project_id': project_id,
+                                    'user_id': user_id,
+                                    'meta': {
+                                        'bucket_name': bucket,
+                                        'expiration_date': expiration_date.isoformat(),
+                                        'days_remaining': days_remaining,
+                                        'warning_threshold': threshold,
+                                    },
+                                    'event_type': 'bucket_expiration_warning',
+                                }
+                            )
+
+                    updated_notified = notified.union(set(new_notifications))
+                    updated_tags = dict(tags)
+                    updated_tags['notified_warnings'] = ','.join(
+                        str(d) for d in sorted(updated_notified)
+                    )
+                    mc.set_bucket_tags(bucket=bucket, tags=updated_tags)
+
+                except Exception as e:
+                    log.warning(
+                        'Error processing bucket %s in project %s: %s',
+                        bucket, project_id, e
+                    )


### PR DESCRIPTION
## Summary

- Add new RPC `artifacts_check_bucket_expiration_notifications` that scans all projects/buckets and sends `notifications_stream` events when buckets are approaching expiration
- Set `expiration_date` and `notified_warnings` tags on bucket creation/update to track expiration state and prevent duplicate notifications
- Fire immediate notification on bucket creation when retention measure is `days`
- Reset `notified_warnings` tag on bucket update so updated retention triggers fresh notifications

## Notification thresholds

| Retention period | Notification at |
|---|---|
| ≥ 365 days (years) | 30d, 7d, 1d before |
| ≥ 30 days (months) | 7d, 1d before |
| ≥ 7 days (weeks) | 5d before |
| < 7 days (days) | Immediately on creation |

## Test plan

- [ ] Create bucket with days retention — immediate notification appears
- [ ] Create bucket with week/month/year retention — no immediate notification
- [ ] Update bucket retention — `notified_warnings` resets, previous thresholds re-trigger
- [ ] `notified_warnings` tag is updated after notification sent (no duplicates on next run)
- [ ] Bucket without `expiration_date` tag is skipped silently

Closes EL-3414

🤖 Generated with [Claude Code](https://claude.com/claude-code)